### PR TITLE
feat: Add basic web interface for device control

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,43 @@ _After any other changes:_
 
 [^3]: Decoding can be verbose (RSSI, Timing, ...)
 
+## Web Interface (Experimental)
+
+This project now includes an experimental web interface to control IOHC devices.
+
+### Setup & Access
+
+1.  **Configure WiFi:**
+    *   Open `src/main.cpp`.
+    *   Locate the `YOUR_SSID` and `YOUR_PASSWORD` placeholders.
+    *   Replace them with your actual WiFi network SSID and password.
+
+2.  **Build and Upload Filesystem:**
+    *   The web interface files (`index.html`, `style.css`, `script.js`) are located in `extras/web_interface_data/`.
+    *   These files need to be uploaded to the ESP32's LittleFS filesystem.
+    *   Using PlatformIO:
+        *   First, build the filesystem image: `pio run --target buildfs` (or use the PlatformIO IDE option for building the filesystem image).
+        *   Then, upload the filesystem image: `pio run --target uploadfs` (or use the PlatformIO IDE option for uploading).
+    *   **Note:** You only need to rebuild and re-upload the filesystem image if you make changes to the files in `extras/web_interface_data/`.
+
+3.  **Build and Upload Firmware:**
+    *   Build and upload the main firmware to your ESP32 as usual using PlatformIO (`pio run --target upload` or via the IDE).
+
+4.  **Find ESP32 IP Address:**
+    *   After uploading, open the Serial Monitor.
+    *   When the ESP32 connects to your WiFi network, it will print its IP address. Look for a line like: `Connected to WiFi. IP Address: XXX.XXX.X.XXX`.
+
+5.  **Access the Interface:**
+    *   Open a web browser on a device connected to the same WiFi network as your ESP32.
+    *   Navigate to the IP address you found in the Serial Monitor (e.g., `http://XXX.XXX.X.XXX`).
+
+### Usage
+
+The web interface allows you to:
+
+*   **View a list of devices:** The device list is currently populated with placeholder examples. (Future development will integrate this with actual detected/configured devices).
+*   **Send commands:** Select a device, type a command string (e.g., `setTemp 21.0`), and click "Send". (Command processing is currently a placeholder and will acknowledge receipt).
+
+This feature is under development, and functionality will be expanded in the future.
+
 #### **License**

--- a/extras/web_interface_data/index.html
+++ b/extras/web_interface_data/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>IOHC Device Control</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>IOHC Device Control</h1>
+    </header>
+
+    <main>
+        <section id="device-list-section">
+            <h2>Devices</h2>
+            <ul id="device-list">
+                <!-- Device items will be populated by JavaScript -->
+                <!-- Example: <li>Device Name <button>On</button> <button>Off</button></li> -->
+            </ul>
+        </section>
+
+        <section id="command-section">
+            <h2>Send Command</h2>
+            <label for="device-select">Select Device:</label>
+            <select id="device-select">
+                <!-- Options will be populated by JavaScript -->
+            </select>
+            <br><br>
+            <label for="command-input">Command:</label>
+            <input type="text" id="command-input" placeholder="e.g., setTemp 22.0">
+            <button id="send-command-button">Send</button>
+        </section>
+
+        <section id="status-section">
+            <h2>Status / Log</h2>
+            <div id="status-messages">
+                <!-- Status messages will be populated by JavaScript -->
+            </div>
+        </section>
+    </main>
+
+    <footer>
+        <p>ESP32 IOHC Controller</p>
+    </footer>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/extras/web_interface_data/script.js
+++ b/extras/web_interface_data/script.js
@@ -1,0 +1,106 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const deviceListUL = document.getElementById('device-list');
+    const deviceSelect = document.getElementById('device-select');
+    const commandInput = document.getElementById('command-input');
+    const sendCommandButton = document.getElementById('send-command-button');
+    const statusMessagesDiv = document.getElementById('status-messages');
+
+    // Function to add a message to the status/log
+    function logStatus(message, isError = false) {
+        const p = document.createElement('p');
+        p.textContent = message;
+        if (isError) {
+            p.style.color = 'red';
+        }
+        statusMessagesDiv.appendChild(p);
+        // Scroll to the bottom of the status messages
+        statusMessagesDiv.scrollTop = statusMessagesDiv.scrollHeight;
+    }
+
+    // Function to fetch devices and populate the lists
+    async function fetchAndDisplayDevices() {
+        try {
+            const response = await fetch('/api/devices');
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+            const devices = await response.json();
+
+            deviceListUL.innerHTML = ''; // Clear existing list
+            deviceSelect.innerHTML = ''; // Clear existing options
+
+            if (devices.length === 0) {
+                logStatus('No devices found.');
+                const listItem = document.createElement('li');
+                listItem.textContent = 'No devices available.';
+                deviceListUL.appendChild(listItem);
+                return;
+            }
+
+            devices.forEach(device => {
+                // Populate the UL for display (simple version)
+                const listItem = document.createElement('li');
+                listItem.textContent = device.name; // Assuming device object has a 'name'
+                // TODO: Add buttons for simple actions if desired in future
+                deviceListUL.appendChild(listItem);
+
+                // Populate the SELECT for command sending
+                const option = document.createElement('option');
+                option.value = device.id; // Assuming device object has an 'id'
+                option.textContent = device.name;
+                deviceSelect.appendChild(option);
+            });
+            logStatus('Device list updated.');
+
+        } catch (error) {
+            logStatus(`Error fetching devices: ${error.message}`, true);
+            console.error('Error fetching devices:', error);
+        }
+    }
+
+    // Function to send a command
+    async function sendCommand() {
+        const selectedDeviceId = deviceSelect.value;
+        const commandStr = commandInput.value.trim();
+
+        if (!selectedDeviceId) {
+            logStatus('Please select a device.', true);
+            return;
+        }
+        if (!commandStr) {
+            logStatus('Please enter a command.', true);
+            return;
+        }
+
+        logStatus(`Sending command "${commandStr}" to device ID ${selectedDeviceId}...`);
+
+        try {
+            const response = await fetch('/api/command', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ deviceId: selectedDeviceId, command: commandStr }),
+            });
+
+            const result = await response.json(); // Expecting JSON response e.g. { success: true, message: "..."}
+
+            if (result.success) {
+                logStatus(`Command success: ${result.message || 'Command processed.'}`);
+            } else {
+                logStatus(`Command failed: ${result.message || 'Unknown error.'}`, true);
+            }
+        } catch (error) {
+            logStatus(`Error sending command: ${error.message}`, true);
+            console.error('Error sending command:', error);
+        }
+    }
+
+    // Event Listeners
+    if (sendCommandButton) {
+        sendCommandButton.addEventListener('click', sendCommand);
+    }
+
+    // Initial fetch of devices
+    fetchAndDisplayDevices();
+});

--- a/extras/web_interface_data/style.css
+++ b/extras/web_interface_data/style.css
@@ -1,0 +1,96 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background-color: #f4f4f4;
+    color: #333;
+}
+
+header {
+    background-color: #333;
+    color: #fff;
+    padding: 1em 0;
+    text-align: center;
+}
+
+header h1 {
+    margin: 0;
+}
+
+main {
+    padding: 1em;
+}
+
+section {
+    background-color: #fff;
+    margin-bottom: 1em;
+    padding: 1em;
+    border-radius: 8px;
+    box-shadow: 0 0 10px rgba(0,0,0,0.1);
+}
+
+h2 {
+    color: #333;
+    border-bottom: 1px solid #eee;
+    padding-bottom: 0.5em;
+}
+
+ul#device-list {
+    list-style-type: none;
+    padding: 0;
+}
+
+ul#device-list li {
+    padding: 0.5em 0;
+    border-bottom: 1px solid #eee;
+}
+
+ul#device-list li:last-child {
+    border-bottom: none;
+}
+
+button {
+    background-color: #5cb85c;
+    color: white;
+    border: none;
+    padding: 10px 15px;
+    text-align: center;
+    text-decoration: none;
+    display: inline-block;
+    font-size: 14px;
+    border-radius: 4px;
+    cursor: pointer;
+    margin-left: 5px;
+}
+
+button:hover {
+    background-color: #4cae4c;
+}
+
+input[type="text"], select {
+    padding: 8px;
+    margin: 5px 0 10px 0;
+    display: inline-block;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-sizing: border-box;
+}
+
+#status-messages {
+    min-height: 50px;
+    border: 1px solid #eee;
+    padding: 10px;
+    background-color: #f9f9f9;
+    border-radius: 4px;
+    white-space: pre-wrap; /* So that newlines in messages are respected */
+}
+
+footer {
+    text-align: center;
+    padding: 1em 0;
+    background-color: #333;
+    color: #fff;
+    position: relative; /* Changed from fixed to relative for simplicity */
+    bottom: 0;
+    width: 100%;
+}

--- a/include/web_server_handler.h
+++ b/include/web_server_handler.h
@@ -1,0 +1,12 @@
+#ifndef WEB_SERVER_HANDLER_H
+#define WEB_SERVER_HANDLER_H
+
+#include <Arduino.h>
+
+// Forward declaration if ESPAsyncWebServer is used
+class ESPAsyncWebServer; 
+
+void setupWebServer();
+void loopWebServer(); // If any loop processing is needed for the web server
+
+#endif // WEB_SERVER_HANDLER_H

--- a/platformio.ini
+++ b/platformio.ini
@@ -60,13 +60,13 @@ lib_deps =
 	${common.lib_deps_builtin}
 ;	${common.lib_deps_external}
 	bblanchon/ArduinoJson ;@^6.21.0
-;	https://github.com/me-no-dev/ESPAsyncWebServer.git
+	https://github.com/me-no-dev/ESPAsyncWebServer.git
 ;	luc-github/ESP32SSDP@^1.2.1
 ;    WiFi
 ;    256dpi/MQTT
 ;	https://github.com/X-Ryl669/esp-eMQTT5.git
 ;    mlesniew/PicoMQTT@^0.3.8
-;	me-no-dev/AsyncTCP@^1.1.1
+	me-no-dev/AsyncTCP@^1.1.1
 	https://github.com/HeMan/async-mqtt-client.git
 ;	marvinroger/AsyncMqttClient@^0.9.0
 ;	jbtronics/ESP32Console ;@^1.2.2

--- a/src/web_server_handler.cpp
+++ b/src/web_server_handler.cpp
@@ -1,0 +1,125 @@
+#include "include/web_server_handler.h"
+#include "ESPAsyncWebServer.h" // Or WebServer.h if that's preferred for memory
+#include "ArduinoJson.h"       // For creating JSON responses
+// #include "main.h" // Or other relevant headers to access device data and command functions
+
+// Assume ESPAsyncWebServer for now.
+// If you use WebServer.h, the setup and request handling will be different.
+AsyncWebServer server(80); // Create AsyncWebServer object on port 80
+
+// Placeholder for actual device data.
+// In a real scenario, this would come from your device management logic.
+struct Device {
+    String id;
+    String name;
+};
+Device devices[] = {
+    {"dev1", "Living Room Thermostat"},
+    {"dev2", "Bedroom Blind"},
+    {"cmd_if", "Command Interface"} // A way to send generic commands if no specific device
+};
+const int numDevices = sizeof(devices) / sizeof(Device);
+
+void handleApiDevices(AsyncWebServerRequest *request) {
+    AsyncJsonResponse* response = new AsyncJsonResponse();
+    JsonArray& root = response->getRoot().to<JsonArray>();
+
+    for (int i = 0; i < numDevices; i++) {
+        JsonObject deviceObj = root.createNestedObject();
+        deviceObj["id"] = devices[i].id;
+        deviceObj["name"] = devices[i].name;
+    }
+    
+    response->setLength();
+    request->send(response);
+    // log_i("Sent device list"); // Requires a logging library
+}
+
+void handleApiCommand(AsyncWebServerRequest *request) {
+    if (request->method() != HTTP_POST) {
+        request->send(405, "text/plain", "Method Not Allowed");
+        return;
+    }
+
+    // Assuming data is sent as JSON. Max size 1024 bytes.
+    // Adjust size if necessary.
+    // The last argument (true) indicates that the data is JSON.
+    // This is specific to ESPAsyncWebServer's JSON body parsing.
+    // If not using ESPAsyncWebServer or its JSON plugin, parse manually.
+    if (request->hasParam("body", true)) {
+        JsonDocument doc; // Using ArduinoJson v6 syntax
+        DeserializationError error = deserializeJson(doc, (uint8_t*)request->getParam("body", true)->value().c_str(), request->getParam("body", true)->value().length());
+
+        if (error) {
+            request->send(400, "application/json", "{\"success\":false, \"message\":\"Invalid JSON\"}");
+            return;
+        }
+
+        String deviceId = doc["deviceId"];
+        String command = doc["command"];
+
+        if (deviceId.isEmpty() || command.isEmpty()) {
+            request->send(400, "application/json", "{\"success\":false, \"message\":\"Missing deviceId or command\"}");
+            return;
+        }
+
+        // TODO: Process the command here
+        // For example, call a function from your main logic:
+        // bool success = processDeviceCommand(deviceId, command);
+        // String message = success ? "Command processed." : "Command failed.";
+        
+        // Placeholder response:
+        String message = "Command received for device " + deviceId + ": '" + command + "'. Processing not yet implemented.";
+        bool success = true; 
+        // log_i("Received command: %s for device %s", command.c_str(), deviceId.c_str());
+
+
+        AsyncJsonResponse* response = new AsyncJsonResponse();
+        JsonObject& root = response->getRoot().to<JsonObject>();
+        root["success"] = success;
+        root["message"] = message;
+        
+        response->setLength();
+        request->send(response);
+
+    } else {
+        request->send(400, "application/json", "{\"success\":false, \"message\":\"No body\"}");
+    }
+}
+
+
+void setupWebServer() {
+    // Serve static files from /web_interface_data
+    // Ensure this path matches where your platformio.ini places data files
+    // or how you upload them (e.g., SPIFFS, LittleFS).
+    // The path "/" serves index.html from the data directory.
+    server.serveStatic("/", LittleFS, "/web_interface_data/").setDefaultFile("index.html");
+    // You might need to explicitly serve each file if serveStatic with directory isn't working as expected
+    // or if files are not in a subdirectory of the data dir.
+    // server.on("/", HTTP_GET, [](AsyncWebServerRequest *request){
+    //     request->send(LittleFS, "/web_interface_data/index.html", "text/html");
+    // });
+    // server.on("/style.css", HTTP_GET, [](AsyncWebServerRequest *request){
+    //     request->send(LittleFS, "/web_interface_data/style.css", "text/css");
+    // });
+    // server.on("/script.js", HTTP_GET, [](AsyncWebServerRequest *request){
+    //     request->send(LittleFS, "/web_interface_data/script.js", "application/javascript");
+    // });
+
+
+    // API Endpoints
+    server.on("/api/devices", HTTP_GET, handleApiDevices);
+    server.addHandler(new AsyncCallbackJsonWebHandler("/api/command", handleApiCommand)); // For POST with JSON
+
+    server.onNotFound([](AsyncWebServerRequest *request){
+        request->send(404, "text/plain", "Not found");
+    });
+
+    server.begin();
+    // log_i("HTTP server started");
+}
+
+void loopWebServer() {
+    // For ESPAsyncWebServer, most work is done asynchronously.
+    // For the basic WebServer.h, you would need server.handleClient() here.
+}


### PR DESCRIPTION
This commit introduces an initial, simple web interface to allow you to interact with IOHC devices through a web browser.

Key changes:
- Adds HTML, CSS, and JavaScript files for the frontend in `extras/web_interface_data/`.
- Implements an ESP32 web server using ESPAsyncWebServer:
    - Serves static web files from LittleFS.
    - Provides API endpoints:
        - `/api/devices`: Returns a list of devices (currently placeholder).
        - `/api/command`: Accepts commands for devices (currently placeholder processing).
- Integrates the web server into `main.cpp`, including LittleFS setup and a basic WiFi connection mechanism (with placeholder credentials).
- Updates `platformio.ini` to include ESPAsyncWebServer and AsyncTCP dependencies.
- Adds a section to `README.md` explaining how to set up and use the new web interface.

This provides a foundational web interface that can be further developed to include dynamic device discovery and real command execution. The focus for this initial implementation was on simplicity and minimal memory footprint.